### PR TITLE
fix: uint conversion

### DIFF
--- a/contracts/wad_ray.cairo
+++ b/contracts/wad_ray.cairo
@@ -24,7 +24,7 @@ namespace WadRay {
 
     // Reverts if `n` overflows or underflows
     func assert_valid{range_check_ptr}(n) {
-        with_attr error_message("WadRay: out of bounds") {
+        with_attr error_message("WadRay: Out of bounds") {
             assert_le(n, BOUND);
             assert_le(-BOUND, n);
         }
@@ -32,7 +32,7 @@ namespace WadRay {
     }
 
     func assert_valid_unsigned{range_check_ptr}(n) {
-        with_attr error_message("WadRay: out of bounds") {
+        with_attr error_message("WadRay: Out of bounds") {
             assert_nn_le(n, BOUND);
         }
         return ();
@@ -187,14 +187,15 @@ namespace WadRay {
     // Conversions
     //
 
-    func to_uint(n) -> (uint: Uint256) {
+    func to_uint{range_check_ptr}(n) -> (uint: Uint256) {
+        assert_valid_unsigned(n);
         let uint = Uint256(low=n, high=0);
         return (uint,);
     }
 
     func from_uint{range_check_ptr}(n: Uint256) -> wad {
         assert n.high = 0;
-        assert_valid(n.low);
+        assert_valid_unsigned(n.low);
         return n.low;
     }
 

--- a/tests/test_wad_ray.cairo
+++ b/tests/test_wad_ray.cairo
@@ -89,7 +89,7 @@ func test_runsigned_div_unchecked{range_check_ptr}(a, b) -> (res: ray) {
 }
 
 @view
-func test_to_uint(n) -> (uint: Uint256) {
+func test_to_uint{range_check_ptr}(n) -> (uint: Uint256) {
     return WadRay.to_uint(n);
 }
 


### PR DESCRIPTION
A maliciously crafted Uint256 struct could pass the from_uint conversion in our lib. An example of this is Uint256(low=-1, high=0), which is not a valid Uint256 value (wouldn't pass uint256_check), but is a valid Uint256 struct. This PR fixes the bug.