### PR TITLE
feat: feature parity for signed

### DIFF
--- a/src/tests/test_wadray_signed.cairo
+++ b/src/tests/test_wadray_signed.cairo
@@ -3,7 +3,8 @@ mod test_wadray_signed {
     use math::Oneable;
     use wadray::wadray::{DIFF, Ray, RAY_ONE, Wad, WAD_ONE};
     use wadray::wadray_signed::{
-        Signed, SignedRay, SignedRayOneable, SignedRayZeroable, SignedWad, SignedWadOneable, SignedWadZeroable
+        BoundedSignedWad, BoundedSignedRay, Signed, SignedRay, SignedRayOneable, SignedRayZeroable, SignedWad,
+        SignedWadOneable, SignedWadZeroable
     };
 
     #[test]
@@ -143,6 +144,17 @@ mod test_wadray_signed {
         assert(zero <= zero, '0 <= 0');
         assert(zero <= a, '0 <= a');
         assert(!(a <= zero), 'a <= 0');
+    }
+
+    #[test]
+    fn test_bounded() {
+        let max_u128 = 0xffffffffffffffffffffffffffffffff;
+
+        assert(BoundedSignedWad::min() == SignedWad { val: max_u128, sign: true }, 'SignedWad min');
+        assert(BoundedSignedWad::max() == SignedWad { val: max_u128, sign: false }, 'SignedWad max');
+
+        assert(BoundedSignedRay::min() == SignedRay { val: max_u128, sign: true }, 'SignedRay min');
+        assert(BoundedSignedRay::max() == SignedRay { val: max_u128, sign: false }, 'SignedRay max');
     }
 
     #[test]

--- a/src/tests/test_wadray_signed.cairo
+++ b/src/tests/test_wadray_signed.cairo
@@ -31,6 +31,26 @@ mod test_wadray_signed {
     }
 
     #[test]
+    fn test_add_eq() {
+        let mut a1 = SignedWad { val: 5, sign: true };
+        let a2 = SignedWad { val: 5, sign: true };
+        let b = SignedWad { val: 3, sign: false };
+
+        a1 += b;
+        assert(a1 == a2 + b, 'Incorrect AddEq #1');
+    }
+
+    #[test]
+    fn test_sub_eq() {
+        let mut a1 = SignedWad { val: 5, sign: true };
+        let a2 = SignedWad { val: 5, sign: true };
+        let b = SignedWad { val: 3, sign: false };
+
+        a1 -= b;
+        assert(a1 == a2 - b, 'Incorrect SubEq #1');
+    }
+
+    #[test]
     fn test_mul_div() {
         let a = SignedWad { val: WAD_ONE, sign: false }; // 1.0 ray
         let b = SignedWad { val: 2 * WAD_ONE, sign: true }; // -2.0 ray
@@ -61,6 +81,26 @@ mod test_wadray_signed {
         assert((c / a) == SignedRay { val: 5 * RAY_ONE, sign: false }, 'c / a != 5.0');
         assert((a / d) == SignedRay { val: 1 * RAY_ONE, sign: true }, 'a / d != -1.0');
         assert((b / d) == SignedRay { val: 2 * RAY_ONE, sign: false }, 'b / d != 2.0');
+    }
+
+    #[test]
+    fn test_mul_eq() {
+        let mut a1 = SignedWad { val: 5, sign: true };
+        let a2 = SignedWad { val: 5, sign: true };
+        let b = SignedWad { val: 3, sign: false };
+
+        a1 *= b;
+        assert(a1 == a2 * b, 'Incorrect MulEq #1');
+    }
+
+    #[test]
+    fn test_div_eq() {
+        let mut a1 = SignedWad { val: 15, sign: true };
+        let a2 = SignedWad { val: 15, sign: true };
+        let b = SignedWad { val: 3, sign: false };
+
+        a1 /= b;
+        assert(a1 == a2 / b, 'Incorrect DivEq #1');
     }
 
     #[test]

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -101,6 +101,20 @@ impl SignedRaySub of Sub<SignedRay> {
     }
 }
 
+impl SignedWadSubEq of SubEq<SignedWad> {
+    #[inline(always)]
+    fn sub_eq(ref self: SignedWad, other: SignedWad) {
+        self = self - other;
+    }
+}
+
+impl SignedRaySubEq of SubEq<SignedRay> {
+    #[inline(always)]
+    fn sub_eq(ref self: SignedRay, other: SignedRay) {
+        self = self - other;
+    }
+}
+
 
 // Multiplication
 impl SignedWadMul of Mul<SignedWad> {
@@ -116,6 +130,20 @@ impl SignedRayMul of Mul<SignedRay> {
         let sign = sign_from_mul(lhs.sign, rhs.sign);
         let val = rmul_internal(lhs.val, rhs.val);
         SignedRay { val: val, sign: sign }
+    }
+}
+
+impl SignedWadMulEq of MulEq<SignedWad> {
+    #[inline(always)]
+    fn mul_eq(ref self: SignedWad, other: SignedWad) {
+        self = self * other;
+    }
+}
+
+impl SignedRayMulEq of MulEq<SignedRay> {
+    #[inline(always)]
+    fn mul_eq(ref self: SignedRay, other: SignedRay) {
+        self = self * other;
     }
 }
 
@@ -136,6 +164,21 @@ impl SignedRayDiv of Div<SignedRay> {
         SignedRay { val: val, sign: sign }
     }
 }
+
+impl SignedWadDivEq of DivEq<SignedWad> {
+    #[inline(always)]
+    fn div_eq(ref self: SignedWad, other: SignedWad) {
+        self = self / other;
+    }
+}
+
+impl SignedRayDivEq of DivEq<SignedRay> {
+    #[inline(always)]
+    fn div_eq(ref self: SignedRay, other: SignedRay) {
+        self = self / other;
+    }
+}
+
 
 // Signed
 impl SignedWadSigned of Signed<SignedWad> {

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -4,10 +4,6 @@ use wadray::wadray::{DIFF, Ray, RAY_ONE, rdiv_internal, rmul_internal, Wad, WAD_
 
 const HALF_PRIME: felt252 = 1809251394333065606848661391547535052811553607665798349986546028067936010240;
 
-trait Signed<T> {
-    fn is_negative(self: T) -> bool;
-    fn is_positive(self: T) -> bool;
-}
 
 #[derive(Copy, Drop, Serde, starknet::Store)]
 struct SignedWad {
@@ -15,6 +11,132 @@ struct SignedWad {
     sign: bool
 }
 
+#[derive(Copy, Drop, Serde, starknet::Store)]
+struct SignedRay {
+    val: u128,
+    sign: bool
+}
+
+//
+// Internal helpers
+//
+
+fn signed_wad_from_felt(val: felt252) -> SignedWad {
+    let wad_val = integer::u128_try_from_felt252(_felt_abs(val)).unwrap();
+    SignedWad { val: wad_val, sign: _felt_sign(val) }
+}
+
+fn signed_ray_from_felt(val: felt252) -> SignedRay {
+    let ray_val = integer::u128_try_from_felt252(_felt_abs(val)).unwrap();
+    SignedRay { val: ray_val, sign: _felt_sign(val) }
+}
+
+// Returns the sign of a signed `felt252` as with signed magnitude representation
+// true = positive
+// false = negative
+#[inline(always)]
+fn _felt_sign(a: felt252) -> bool {
+    integer::u256_from_felt252(a) > integer::u256_from_felt252(HALF_PRIME)
+}
+
+// Returns the absolute value of a signed `felt252`
+fn _felt_abs(a: felt252) -> felt252 {
+    let a_sign = _felt_sign(a);
+
+    if !a_sign {
+        a
+    } else {
+        a * -1
+    }
+}
+
+// Returns the sign of the product in signed multiplication (or quotient in division)
+fn sign_from_mul(lhs_sign: bool, rhs_sign: bool) -> bool {
+    (!lhs_sign && rhs_sign) || (lhs_sign && !rhs_sign)
+}
+
+//
+// Trait Implementations
+//
+
+// Addition
+impl SignedWadAdd of Add<SignedWad> {
+    fn add(lhs: SignedWad, rhs: SignedWad) -> SignedWad {
+        signed_wad_from_felt(lhs.into() + rhs.into())
+    }
+}
+
+impl SignedWadAddEq of AddEq<SignedWad> {
+    #[inline(always)]
+    fn add_eq(ref self: SignedWad, other: SignedWad) {
+        self = self + other;
+    }
+}
+
+impl SignedRayAdd of Add<SignedRay> {
+    fn add(lhs: SignedRay, rhs: SignedRay) -> SignedRay {
+        signed_ray_from_felt(lhs.into() + rhs.into())
+    }
+}
+
+impl SignedRayAddEq of AddEq<SignedRay> {
+    #[inline(always)]
+    fn add_eq(ref self: SignedRay, other: SignedRay) {
+        self = self + other;
+    }
+}
+
+
+// Subtraction
+impl SignedWadSub of Sub<SignedWad> {
+    fn sub(lhs: SignedWad, rhs: SignedWad) -> SignedWad {
+        signed_wad_from_felt(lhs.into() - rhs.into())
+    }
+}
+
+impl SignedRaySub of Sub<SignedRay> {
+    fn sub(lhs: SignedRay, rhs: SignedRay) -> SignedRay {
+        signed_ray_from_felt(lhs.into() - rhs.into())
+    }
+}
+
+
+// Multiplication
+impl SignedWadMul of Mul<SignedWad> {
+    fn mul(lhs: SignedWad, rhs: SignedWad) -> SignedWad {
+        let sign = sign_from_mul(lhs.sign, rhs.sign);
+        let val = wmul_internal(lhs.val, rhs.val);
+        SignedWad { val: val, sign: sign }
+    }
+}
+
+impl SignedRayMul of Mul<SignedRay> {
+    fn mul(lhs: SignedRay, rhs: SignedRay) -> SignedRay {
+        let sign = sign_from_mul(lhs.sign, rhs.sign);
+        let val = rmul_internal(lhs.val, rhs.val);
+        SignedRay { val: val, sign: sign }
+    }
+}
+
+
+// Division
+impl SignedWadDiv of Div<SignedWad> {
+    fn div(lhs: SignedWad, rhs: SignedWad) -> SignedWad {
+        let sign = sign_from_mul(lhs.sign, rhs.sign);
+        let val = wdiv_internal(lhs.val, rhs.val);
+        SignedWad { val: val, sign: sign }
+    }
+}
+
+impl SignedRayDiv of Div<SignedRay> {
+    fn div(lhs: SignedRay, rhs: SignedRay) -> SignedRay {
+        let sign = sign_from_mul(lhs.sign, rhs.sign);
+        let val = rdiv_internal(lhs.val, rhs.val);
+        SignedRay { val: val, sign: sign }
+    }
+}
+
+// Signed
 impl SignedWadSigned of Signed<SignedWad> {
     fn is_negative(self: SignedWad) -> bool {
         self.val > 0 && self.sign
@@ -25,6 +147,8 @@ impl SignedWadSigned of Signed<SignedWad> {
     }
 }
 
+
+// Conversions
 impl SignedWadIntoFelt252 of Into<SignedWad, felt252> {
     fn into(self: SignedWad) -> felt252 {
         let mag_felt: felt252 = self.val.into();
@@ -59,69 +183,36 @@ impl SignedWadTryIntoWad of TryInto<SignedWad, Wad> {
     }
 }
 
-
-impl SignedWadAdd of Add<SignedWad> {
-    fn add(lhs: SignedWad, rhs: SignedWad) -> SignedWad {
-        signed_wad_from_felt(lhs.into() + rhs.into())
+impl U128IntoSignedRay of Into<u128, SignedRay> {
+    fn into(self: u128) -> SignedRay {
+        SignedRay { val: self, sign: false }
     }
 }
 
-impl SignedWadSub of Sub<SignedWad> {
-    fn sub(lhs: SignedWad, rhs: SignedWad) -> SignedWad {
-        signed_wad_from_felt(lhs.into() - rhs.into())
+impl RayIntoSignedRay of Into<Ray, SignedRay> {
+    fn into(self: Ray) -> SignedRay {
+        SignedRay { val: self.val, sign: false }
     }
 }
 
-impl SignedWadMul of Mul<SignedWad> {
-    fn mul(lhs: SignedWad, rhs: SignedWad) -> SignedWad {
-        let sign = sign_from_mul(lhs.sign, rhs.sign);
-        let val = wmul_internal(lhs.val, rhs.val);
-        SignedWad { val: val, sign: sign }
+impl WadIntoSignedRay of Into<Wad, SignedRay> {
+    fn into(self: Wad) -> SignedRay {
+        SignedRay { val: self.val * DIFF, sign: false }
     }
 }
 
-impl SignedWadDiv of Div<SignedWad> {
-    fn div(lhs: SignedWad, rhs: SignedWad) -> SignedWad {
-        let sign = sign_from_mul(lhs.sign, rhs.sign);
-        let val = wdiv_internal(lhs.val, rhs.val);
-        SignedWad { val: val, sign: sign }
+impl SignedRayTryIntoRay of TryInto<SignedRay, Ray> {
+    fn try_into(self: SignedRay) -> Option<Ray> {
+        if !self.sign {
+            return Option::Some(Ray { val: self.val });
+        } else {
+            return Option::None;
+        }
     }
 }
 
-impl SignedWadZeroable of Zeroable<SignedWad> {
-    #[inline(always)]
-    fn zero() -> SignedWad {
-        SignedWad { val: 0, sign: false }
-    }
 
-    #[inline(always)]
-    fn is_zero(self: SignedWad) -> bool {
-        self.val == 0
-    }
-
-    #[inline(always)]
-    fn is_non_zero(self: SignedWad) -> bool {
-        self.val != 0
-    }
-}
-
-impl SignedWadOneable of Oneable<SignedWad> {
-    #[inline(always)]
-    fn one() -> SignedWad {
-        SignedWad { val: WAD_ONE, sign: false }
-    }
-
-    #[inline(always)]
-    fn is_one(self: SignedWad) -> bool {
-        self.val == WAD_ONE && !self.sign
-    }
-
-    #[inline(always)]
-    fn is_non_one(self: SignedWad) -> bool {
-        self.val != WAD_ONE || self.sign
-    }
-}
-
+// Comparisons
 impl SignedWadPartialEq of PartialEq<SignedWad> {
     fn eq(lhs: @SignedWad, rhs: @SignedWad) -> bool {
         let val_cmp: bool = *lhs.val == *rhs.val;
@@ -134,13 +225,6 @@ impl SignedWadPartialEq of PartialEq<SignedWad> {
 
     fn ne(lhs: @SignedWad, rhs: @SignedWad) -> bool {
         !(*lhs == *rhs)
-    }
-}
-
-impl SignedWadAddEq of AddEq<SignedWad> {
-    #[inline(always)]
-    fn add_eq(ref self: SignedWad, other: SignedWad) {
-        self = self + other;
     }
 }
 
@@ -182,132 +266,6 @@ impl SignedWadPartialOrd of PartialOrd<SignedWad> {
     }
 }
 
-
-fn signed_wad_from_felt(val: felt252) -> SignedWad {
-    let wad_val = integer::u128_try_from_felt252(_felt_abs(val)).unwrap();
-    SignedWad { val: wad_val, sign: _felt_sign(val) }
-}
-
-
-#[derive(Copy, Drop, Serde, starknet::Store)]
-struct SignedRay {
-    val: u128,
-    sign: bool
-}
-
-impl SignedRaySigned of Signed<SignedRay> {
-    fn is_negative(self: SignedRay) -> bool {
-        self.val > 0 && self.sign
-    }
-
-    fn is_positive(self: SignedRay) -> bool {
-        self.val > 0 && !self.sign
-    }
-}
-
-impl SignedRayIntoFelt252 of Into<SignedRay, felt252> {
-    fn into(self: SignedRay) -> felt252 {
-        let mag_felt: felt252 = self.val.into();
-
-        if self.sign {
-            return mag_felt * -1;
-        } else {
-            return mag_felt;
-        }
-    }
-}
-
-impl U128IntoSignedRay of Into<u128, SignedRay> {
-    fn into(self: u128) -> SignedRay {
-        SignedRay { val: self, sign: false }
-    }
-}
-
-impl RayIntoSignedRay of Into<Ray, SignedRay> {
-    fn into(self: Ray) -> SignedRay {
-        SignedRay { val: self.val, sign: false }
-    }
-}
-
-impl WadIntoSignedRay of Into<Wad, SignedRay> {
-    fn into(self: Wad) -> SignedRay {
-        SignedRay { val: self.val * DIFF, sign: false }
-    }
-}
-
-impl SignedRayTryIntoRay of TryInto<SignedRay, Ray> {
-    fn try_into(self: SignedRay) -> Option<Ray> {
-        if !self.sign {
-            return Option::Some(Ray { val: self.val });
-        } else {
-            return Option::None;
-        }
-    }
-}
-
-
-impl SignedRayAdd of Add<SignedRay> {
-    fn add(lhs: SignedRay, rhs: SignedRay) -> SignedRay {
-        signed_ray_from_felt(lhs.into() + rhs.into())
-    }
-}
-
-impl SignedRaySub of Sub<SignedRay> {
-    fn sub(lhs: SignedRay, rhs: SignedRay) -> SignedRay {
-        signed_ray_from_felt(lhs.into() - rhs.into())
-    }
-}
-
-impl SignedRayMul of Mul<SignedRay> {
-    fn mul(lhs: SignedRay, rhs: SignedRay) -> SignedRay {
-        let sign = sign_from_mul(lhs.sign, rhs.sign);
-        let val = rmul_internal(lhs.val, rhs.val);
-        SignedRay { val: val, sign: sign }
-    }
-}
-
-impl SignedRayDiv of Div<SignedRay> {
-    fn div(lhs: SignedRay, rhs: SignedRay) -> SignedRay {
-        let sign = sign_from_mul(lhs.sign, rhs.sign);
-        let val = rdiv_internal(lhs.val, rhs.val);
-        SignedRay { val: val, sign: sign }
-    }
-}
-
-impl SignedRayZeroable of Zeroable<SignedRay> {
-    #[inline(always)]
-    fn zero() -> SignedRay {
-        SignedRay { val: 0, sign: false }
-    }
-
-    #[inline(always)]
-    fn is_zero(self: SignedRay) -> bool {
-        self.val == 0
-    }
-
-    #[inline(always)]
-    fn is_non_zero(self: SignedRay) -> bool {
-        self.val != 0
-    }
-}
-
-impl SignedRayOneable of Oneable<SignedRay> {
-    #[inline(always)]
-    fn one() -> SignedRay {
-        SignedRay { val: RAY_ONE, sign: false }
-    }
-
-    #[inline(always)]
-    fn is_one(self: SignedRay) -> bool {
-        self.val == RAY_ONE && !self.sign
-    }
-
-    #[inline(always)]
-    fn is_non_one(self: SignedRay) -> bool {
-        self.val != RAY_ONE || self.sign
-    }
-}
-
 impl SignedRayPartialEq of PartialEq<SignedRay> {
     fn eq(lhs: @SignedRay, rhs: @SignedRay) -> bool {
         let val_cmp: bool = *lhs.val == *rhs.val;
@@ -320,13 +278,6 @@ impl SignedRayPartialEq of PartialEq<SignedRay> {
 
     fn ne(lhs: @SignedRay, rhs: @SignedRay) -> bool {
         !(*lhs == *rhs)
-    }
-}
-
-impl SignedRayAddEq of AddEq<SignedRay> {
-    #[inline(always)]
-    fn add_eq(ref self: SignedRay, other: SignedRay) {
-        self = self + other;
     }
 }
 
@@ -369,31 +320,102 @@ impl SignedRayPartialOrd of PartialOrd<SignedRay> {
 }
 
 
-fn signed_ray_from_felt(val: felt252) -> SignedRay {
-    let ray_val = integer::u128_try_from_felt252(_felt_abs(val)).unwrap();
-    SignedRay { val: ray_val, sign: _felt_sign(val) }
-}
+// Zeroable
+impl SignedWadZeroable of Zeroable<SignedWad> {
+    #[inline(always)]
+    fn zero() -> SignedWad {
+        SignedWad { val: 0, sign: false }
+    }
 
-// Returns the sign of a signed `felt252` as with signed magnitude representation
-// true = positive
-// false = negative
-#[inline(always)]
-fn _felt_sign(a: felt252) -> bool {
-    integer::u256_from_felt252(a) > integer::u256_from_felt252(HALF_PRIME)
-}
+    #[inline(always)]
+    fn is_zero(self: SignedWad) -> bool {
+        self.val == 0
+    }
 
-// Returns the absolute value of a signed `felt252`
-fn _felt_abs(a: felt252) -> felt252 {
-    let a_sign = _felt_sign(a);
-
-    if !a_sign {
-        a
-    } else {
-        a * -1
+    #[inline(always)]
+    fn is_non_zero(self: SignedWad) -> bool {
+        self.val != 0
     }
 }
 
-// Returns the sign of the product in signed multiplication (or quotient in division)
-fn sign_from_mul(lhs_sign: bool, rhs_sign: bool) -> bool {
-    (!lhs_sign && rhs_sign) || (lhs_sign && !rhs_sign)
+impl SignedRayZeroable of Zeroable<SignedRay> {
+    #[inline(always)]
+    fn zero() -> SignedRay {
+        SignedRay { val: 0, sign: false }
+    }
+
+    #[inline(always)]
+    fn is_zero(self: SignedRay) -> bool {
+        self.val == 0
+    }
+
+    #[inline(always)]
+    fn is_non_zero(self: SignedRay) -> bool {
+        self.val != 0
+    }
+}
+
+
+// Oneable
+impl SignedWadOneable of Oneable<SignedWad> {
+    #[inline(always)]
+    fn one() -> SignedWad {
+        SignedWad { val: WAD_ONE, sign: false }
+    }
+
+    #[inline(always)]
+    fn is_one(self: SignedWad) -> bool {
+        self.val == WAD_ONE && !self.sign
+    }
+
+    #[inline(always)]
+    fn is_non_one(self: SignedWad) -> bool {
+        self.val != WAD_ONE || self.sign
+    }
+}
+
+impl SignedRayOneable of Oneable<SignedRay> {
+    #[inline(always)]
+    fn one() -> SignedRay {
+        SignedRay { val: RAY_ONE, sign: false }
+    }
+
+    #[inline(always)]
+    fn is_one(self: SignedRay) -> bool {
+        self.val == RAY_ONE && !self.sign
+    }
+
+    #[inline(always)]
+    fn is_non_one(self: SignedRay) -> bool {
+        self.val != RAY_ONE || self.sign
+    }
+}
+
+
+// Signed
+trait Signed<T> {
+    fn is_negative(self: T) -> bool;
+    fn is_positive(self: T) -> bool;
+}
+
+impl SignedRaySigned of Signed<SignedRay> {
+    fn is_negative(self: SignedRay) -> bool {
+        self.val > 0 && self.sign
+    }
+
+    fn is_positive(self: SignedRay) -> bool {
+        self.val > 0 && !self.sign
+    }
+}
+
+impl SignedRayIntoFelt252 of Into<SignedRay, felt252> {
+    fn into(self: SignedRay) -> felt252 {
+        let mag_felt: felt252 = self.val.into();
+
+        if self.sign {
+            return mag_felt * -1;
+        } else {
+            return mag_felt;
+        }
+    }
 }

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -180,19 +180,19 @@ impl SignedRayDivEq of DivEq<SignedRay> {
 }
 
 
-// Signed
-impl SignedWadSigned of Signed<SignedWad> {
-    fn is_negative(self: SignedWad) -> bool {
-        self.val > 0 && self.sign
-    }
-
-    fn is_positive(self: SignedWad) -> bool {
-        self.val > 0 && !self.sign
+// Conversions
+impl U128IntoSignedWad of Into<u128, SignedWad> {
+    fn into(self: u128) -> SignedWad {
+        SignedWad { val: self, sign: false }
     }
 }
 
+impl U128IntoSignedRay of Into<u128, SignedRay> {
+    fn into(self: u128) -> SignedRay {
+        SignedRay { val: self, sign: false }
+    }
+}
 
-// Conversions
 impl SignedWadIntoFelt252 of Into<SignedWad, felt252> {
     fn into(self: SignedWad) -> felt252 {
         let mag_felt: felt252 = self.val.into();
@@ -205,15 +205,33 @@ impl SignedWadIntoFelt252 of Into<SignedWad, felt252> {
     }
 }
 
-impl U128IntoSignedWad of Into<u128, SignedWad> {
-    fn into(self: u128) -> SignedWad {
-        SignedWad { val: self, sign: false }
+impl SignedRayIntoFelt252 of Into<SignedRay, felt252> {
+    fn into(self: SignedRay) -> felt252 {
+        let mag_felt: felt252 = self.val.into();
+
+        if self.sign {
+            return mag_felt * -1;
+        } else {
+            return mag_felt;
+        }
     }
 }
 
 impl WadIntoSignedWad of Into<Wad, SignedWad> {
     fn into(self: Wad) -> SignedWad {
         SignedWad { val: self.val, sign: false }
+    }
+}
+
+impl WadIntoSignedRay of Into<Wad, SignedRay> {
+    fn into(self: Wad) -> SignedRay {
+        SignedRay { val: self.val * DIFF, sign: false }
+    }
+}
+
+impl RayIntoSignedRay of Into<Ray, SignedRay> {
+    fn into(self: Ray) -> SignedRay {
+        SignedRay { val: self.val, sign: false }
     }
 }
 
@@ -224,24 +242,6 @@ impl SignedWadTryIntoWad of TryInto<SignedWad, Wad> {
         } else {
             return Option::None;
         }
-    }
-}
-
-impl U128IntoSignedRay of Into<u128, SignedRay> {
-    fn into(self: u128) -> SignedRay {
-        SignedRay { val: self, sign: false }
-    }
-}
-
-impl RayIntoSignedRay of Into<Ray, SignedRay> {
-    fn into(self: Ray) -> SignedRay {
-        SignedRay { val: self.val, sign: false }
-    }
-}
-
-impl WadIntoSignedRay of Into<Wad, SignedRay> {
-    fn into(self: Wad) -> SignedRay {
-        SignedRay { val: self.val * DIFF, sign: false }
     }
 }
 
@@ -468,6 +468,16 @@ trait Signed<T> {
     fn is_positive(self: T) -> bool;
 }
 
+impl SignedWadSigned of Signed<SignedWad> {
+    fn is_negative(self: SignedWad) -> bool {
+        self.val > 0 && self.sign
+    }
+
+    fn is_positive(self: SignedWad) -> bool {
+        self.val > 0 && !self.sign
+    }
+}
+
 impl SignedRaySigned of Signed<SignedRay> {
     fn is_negative(self: SignedRay) -> bool {
         self.val > 0 && self.sign
@@ -475,17 +485,5 @@ impl SignedRaySigned of Signed<SignedRay> {
 
     fn is_positive(self: SignedRay) -> bool {
         self.val > 0 && !self.sign
-    }
-}
-
-impl SignedRayIntoFelt252 of Into<SignedRay, felt252> {
-    fn into(self: SignedRay) -> felt252 {
-        let mag_felt: felt252 = self.val.into();
-
-        if self.sign {
-            return mag_felt * -1;
-        } else {
-            return mag_felt;
-        }
     }
 }

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -1,4 +1,5 @@
 use debug::PrintTrait;
+use integer::BoundedInt;
 use math::Oneable;
 use wadray::wadray::{DIFF, Ray, RAY_ONE, rdiv_internal, rmul_internal, Wad, WAD_ONE, wdiv_internal, wmul_internal};
 
@@ -316,6 +317,32 @@ impl SignedRayPartialOrd of PartialOrd<SignedRay> {
         } else {
             (lhs.val != rhs.val) && ((lhs.val > rhs.val) ^ lhs.sign)
         }
+    }
+}
+
+
+// Bounded
+impl BoundedSignedWad of BoundedInt<SignedWad> {
+    #[inline(always)]
+    fn min() -> SignedWad nopanic {
+        SignedWad { val: integer::BoundedU128::max(), sign: true }
+    }
+
+    #[inline(always)]
+    fn max() -> SignedWad nopanic {
+        SignedWad { val: integer::BoundedU128::max(), sign: false }
+    }
+}
+
+impl BoundedSignedRay of BoundedInt<SignedRay> {
+    #[inline(always)]
+    fn min() -> SignedRay nopanic {
+        SignedRay { val: integer::BoundedU128::max(), sign: true }
+    }
+
+    #[inline(always)]
+    fn max() -> SignedRay nopanic {
+        SignedRay { val: integer::BoundedU128::max(), sign: false }
     }
 }
 


### PR DESCRIPTION
Resolves #13.

This PR implements the `BoundedInt`, `SubEq`, `MulEq` and `DivEq` traits for `SignedWad` and `SignedRay`, so as to achieve feature parity with `Wad` and `Ray`.

Also, I have reordered the sections to mimic `wadray.cairo`.